### PR TITLE
fix: replace `merge()` with `Object.assign()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "execa": "^5.1.1",
     "floggy": "^0.2.3",
     "fs-jetpack": "^4.1.1",
-    "lodash": "^4.17.21",
     "playwright": "^1.15.1",
     "tslib": "^2.3.1"
   },
@@ -67,7 +66,6 @@
     "@homer0/prettier-plugin-jsdoc": "4.0.5",
     "@prisma-labs/prettier-config": "0.1.0",
     "@types/jest": "27.0.1",
-    "@types/lodash": "^4.14.173",
     "@types/node": "16.9.1",
     "@types/ts-nameof": "4.2.1",
     "@typescript-eslint/eslint-plugin": "4.31.0",

--- a/src/runners.ts
+++ b/src/runners.ts
@@ -1,4 +1,3 @@
-import { merge } from 'lodash'
 import ono from '@jsdevtools/ono'
 import { HookNames, jestHookLookup, jestHookToPhase } from './jest'
 import { kontLog } from './log'
@@ -35,7 +34,7 @@ export const runSetup = (params: {
       )
     }
 
-    merge(params.currentContext, contributedContext ?? {})
+    Object.assign(params.currentContext, contributedContext ?? {})
 
     log.trace('did_setup', { contributedContext })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1185,13 +1185,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:^4.14.173":
-  version: 4.14.173
-  resolution: "@types/lodash@npm:4.14.173"
-  checksum: 9e97ef5816299e5470db1cb32a93e981af60f74f18a35d045ed4caf224a065df96bfae6e444ec96aa392fc01258592b965d840ae042eef77ef719a578c7daef8
-  languageName: node
-  linkType: hard
-
 "@types/ms@npm:*":
   version: 0.7.31
   resolution: "@types/ms@npm:0.7.31"
@@ -4520,7 +4513,6 @@ fsevents@^2.3.2:
     "@jsdevtools/ono": ^7.1.3
     "@prisma-labs/prettier-config": 0.1.0
     "@types/jest": 27.0.1
-    "@types/lodash": ^4.14.173
     "@types/node": 16.9.1
     "@types/ts-nameof": 4.2.1
     "@typescript-eslint/eslint-plugin": 4.31.0
@@ -4537,7 +4529,6 @@ fsevents@^2.3.2:
     jest-watch-select-projects: 2.0.0
     jest-watch-suspend: 1.1.2
     jest-watch-typeahead: 0.6.4
-    lodash: ^4.17.21
     markdown-toc: ^1.2.0
     playwright: ^1.15.1
     prettier: 2.4.0


### PR DESCRIPTION
## Background

In my tests - I often spin up servers as part of `beforeEach`. In the particular area where I encountered problems is that my test server kept track of incoming requests by a mutable array. Couldn't for the life of me understand why the array was constantly empty, but I think this was the culprit.

To be even more specific, I was testing a websocket trigger/receiver - so I in my tests I dynamically use `http.createServer()` & later I want to assert that the server received events as after doing specific actions in my app.



#### TODO

- ~[ ] docs~ behaviour was not docced before as far as I can tell
- ~[ ] tests~ seem to have been unchanged as well
